### PR TITLE
Add `Webhook` automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,15 @@ Pre-requisites: `Node 18^` & `pm2` installed.
     - Click on **Add Custom Integration**.
     - Name the integration (e.g., Newsletters) and click **Add**.
     - **Copy** the **Admin API Key** displayed.
-3. **Set Up Webhook**:
-    - In the same section, scroll down to **Add Webhook**.
-    - Name the webhook (e.g., Send Newsletter).
-    - Select **Post published** as the event.
-    - Set the **Target Url** to `https://your-domain.com/published`.
-    - Click **Add** to finalize.
-4. **Configure Ghosler**:
+3. **Configure Ghosler**:
     - Fire up the Ghosler front-end by going to `https://your-domain.com`. Default `PORT` is `2369`.
     - Click on **Settings** button.
     - Click on **Ghost Settings** & add your **Ghost Site Url** & **Admin API Key**.
+    - Add mail configurations in **Emails** section.
     - Change other settings you wish to and click **Save Changes**.
+      Upon clicking **Save Changes**, Ghosler will automatically create a new `Webhook` in the Ghost Integration (if it
+      doesn't already exist).
+      This webhook enables **Ghosler** to receive information about posts when they are published.
 
 Now as soon as you publish your Post, it will be sent to your Subscribers who have enabled receiving emails.
 

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import Ghost from '../utils/api/ghost.js';
 import ProjectConfigs from '../utils/data/configs.js';
 
 const router = express.Router();
@@ -16,6 +17,16 @@ router.post('/', async (req, res) => {
     const configs = await ProjectConfigs.all();
 
     const {level, message} = result;
+
+    if (configs.ghost.url && configs.ghost.key) {
+        const ghost = new Ghost();
+        const response = await ghost.registerWebhook();
+        if (response.level === 'error') {
+            res.render('index', response);
+            return;
+        }
+    }
+
     res.render('dashboard/settings', {level, message, configs});
 });
 

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -16,14 +16,15 @@ router.post('/', async (req, res) => {
     const result = await ProjectConfigs.update(formData);
     const configs = await ProjectConfigs.all();
 
-    const {level, message} = result;
+    let {level, message} = result;
 
     if (configs.ghost.url && configs.ghost.key) {
         const ghost = new Ghost();
         const response = await ghost.registerWebhook();
+
         if (response.level === 'error') {
-            res.render('index', response);
-            return;
+            level = response.level;
+            message = response.message;
         }
     }
 

--- a/utils/api/ghost.js
+++ b/utils/api/ghost.js
@@ -123,7 +123,9 @@ export default class Ghost {
             return {level: 'success', message: 'Webhook created successfully.'};
         } catch (error) {
             const context = error.context;
-            if (context === 'Target URL has already been used for this event.') {
+            if (error.name === 'UnauthorizedError') {
+                return {level: 'error', message: 'Unable to check for Webhook, Ghost Admin API not valid.'};
+            } else if (context === 'Target URL has already been used for this event.') {
                 return {level: 'success', message: 'Webhook exists for this API Key.'};
             } else {
                 logError(logTags.Ghost, error);

--- a/utils/data/configs.js
+++ b/utils/data/configs.js
@@ -136,6 +136,10 @@ export default class ProjectConfigs {
         configs.ghosler.auth.user = user;
         if (configs.ghosler.url !== url) configs.ghosler.url = url;
 
+        if (ghostUrl === '' || ghostAdminKey === '') {
+            return {level: 'error', message: 'Ghost URL or Admin API Key is missing.'};
+        }
+
         // ghost
         configs.ghost.url = ghostUrl;
         configs.ghost.key = ghostAdminKey;


### PR DESCRIPTION
This PR adds the ability to register a `Webhook` on Ghost integration without the user having to do so.
One step lesser to setting up Ghosler! 🎉

Closes #3.