### PR TITLE
Custom Template Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules
 
 # debug configuration
 config.debug.json
+
+# custom template used for tests
+custom-template.ejs

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ and opens, with the capability to use **multiple** email accounts.
 - **Support for Multiple Email Accounts**: Distribute newsletters through various email accounts, dividing member counts
   accordingly.
 - **Tracking Email Performance**: Monitor email deliverability and open rates.
-- **Customize Newsletter**: You can customize the newsletter via Settings, or go full on by editing the `*.ejs` files.
+- **Customize Newsletter**: You can customize the newsletter via Settings, or go full on by providing
+  a [custom template](#custom-template).
 - **Paid & Free Members Management**: Ghosler shows a **Subscribe** button to members who do not have access to paid
   content.
 
@@ -53,6 +54,15 @@ Now as soon as you publish your Post, it will be sent to your Subscribers who ha
 
 Ghosler will always use a debug version of the configs i.e. `config.debug.json` if one exists. The JSON schema is the
 same as in the [config.production.json](./config.production.json) file.
+
+#### Custom Template
+
+If you want to customize the newsletter template even more, follow the steps -
+
+1. Create a **custom-template.ejs** in the root directory.
+2. Customize it as you like, take a look at [pre-defined template](./views/newsletter.ejs) for reference.
+3. That's it! Ghosler will use the new template for preview & sending newsletter.
+4. Rename the file to anything if you don't want to use the custom template.
 
 ### TODOs
 

--- a/routes/preview.js
+++ b/routes/preview.js
@@ -1,10 +1,18 @@
+import ejs from 'ejs';
 import express from 'express';
+import Files from '../utils/data/files.js';
 import Newsletter from '../utils/newsletter.js';
 
 const router = express.Router();
 
 router.get('/', async (_, res) => {
-    res.render('newsletter', await Newsletter.preview());
+    const preview = await Newsletter.preview();
+
+    if (await Files.customTemplateExists()) {
+        const templatePath = Files.customTemplatePath();
+        const template = await ejs.renderFile(templatePath, preview);
+        res.set('Content-Type', 'text/html').send(Buffer.from(template));
+    } else res.render('newsletter', preview);
 });
 
 export default router;

--- a/utils/data/files.js
+++ b/utils/data/files.js
@@ -23,6 +23,13 @@ export default class Files {
     }
 
     /**
+     * Get the custom template's path.
+     */
+    static #customTemplatePath() {
+        return path.join(process.cwd(), 'custom-template.ejs');
+    }
+
+    /**
      * * Asynchronously creates a JSON file with a specified name in a predefined directory.
      *
      * @param {Object} post - The post data to be saved as a file.
@@ -181,6 +188,29 @@ export default class Files {
             // empty anyway!
             return {content: '', level: type};
         }
+    }
+
+    /**
+     * Checks whether the user has supplied a custom template to be used for preview & emails.
+     *
+     * @returns {Promise<boolean>} True if a file named 'custom-template.ejs' exists.
+     */
+    static async customTemplateExists() {
+        try {
+            await fs.access(this.#customTemplatePath());
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the Path for the custom template.
+     *
+     * @returns {string} Path of the file.
+     */
+    static customTemplatePath() {
+        return this.#customTemplatePath();
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to allow developers use a custom template for preview & newsletters.

---
Pre-requisites to use the featue:
1. The custom template **should** be in the root directory of the project & **must** be named **`custom-template.ejs`**.
2. And thats it!

See the pre-defined template in `views/newsletter.ejs` directory for reference.

---
Completes #6.