### PR TITLE
Post Content Link Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ and opens, with the capability to use **multiple** email accounts.
   a [custom template](#custom-template).
 - **Paid & Free Members Management**: Ghosler shows a **Subscribe** button to members who do not have access to paid
   content.
+- **Link Click Tracking in Emails**: Ghosler supports tracking URL clicks in the email, providing more insights on how
+  your members are interacting with added links.
 
 ### Running Ghosler
 

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ Miscellaneous.setup(expressApp).then();
 
 // define routes
 logDebug('Express', 'Setting routes...');
+expressApp.use(track);
 expressApp.use('/', index);
 expressApp.use('/logs', logs);
 expressApp.use('/preview', preview);
@@ -25,7 +26,6 @@ expressApp.use('/settings', settings);
 expressApp.use('/password', password);
 expressApp.use('/analytics', analytics);
 expressApp.use('/published', published);
-expressApp.use('/track/pixel.png', track);
 
 // custom 404 after all the pages have been set up.
 expressApp.use((req, res) => res.status(404).render('errors/404'));

--- a/config.production.json
+++ b/config.production.json
@@ -19,7 +19,8 @@
     "show_subscription": true,
     "show_featured_image": true,
     "show_powered_by_ghost": true,
-    "show_powered_by_ghosler": true
+    "show_powered_by_ghosler": true,
+    "track_links": true
   },
   "mail": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ghosler",
-  "version": "0.3",
+  "version": "0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.3",
+      "version": "0.4",
       "dependencies": {
         "@tryghost/admin-api": "^1.13.11",
         "ejs": "3.1.9",
         "express": "^4.18.2",
+        "he": "^1.2.0",
         "jsonwebtoken": "^9.0.0",
         "nodemailer": "^6.9.5",
         "winston": "^3.11.0"
@@ -621,6 +622,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/http-errors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.4",
+  "version": "0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.4",
+      "version": "0.5",
       "dependencies": {
         "@tryghost/admin-api": "^1.13.11",
         "ejs": "3.1.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.4",
+  "version": "0.5",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@tryghost/admin-api": "^1.13.11",
     "ejs": "3.1.9",
     "express": "^4.18.2",
+    "he": "^1.2.0",
     "jsonwebtoken": "^9.0.0",
     "nodemailer": "^6.9.5",
     "winston": "^3.11.0"

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -13,4 +13,10 @@ router.post('/delete/:postId', async (req, res) => {
     res.send(result);
 });
 
+router.get('/links/:postId', async (req, res) => {
+    const postId = req.params.postId;
+    const post = await Files.get(postId);
+    res.render('dashboard/links', post);
+});
+
 export default router;

--- a/routes/preview.js
+++ b/routes/preview.js
@@ -1,18 +1,12 @@
-import ejs from 'ejs';
 import express from 'express';
-import Files from '../utils/data/files.js';
 import Newsletter from '../utils/newsletter.js';
 
 const router = express.Router();
 
 router.get('/', async (_, res) => {
     const preview = await Newsletter.preview();
-
-    if (await Files.customTemplateExists()) {
-        const templatePath = Files.customTemplatePath();
-        const template = await ejs.renderFile(templatePath, preview);
-        res.set('Content-Type', 'text/html').send(Buffer.from(template));
-    } else res.render('newsletter', preview);
+    const template = await Newsletter.renderTemplate(preview);
+    res.set('Content-Type', 'text/html').send(template.modifiedHtml);
 });
 
 export default router;

--- a/utils/data/configs.js
+++ b/utils/data/configs.js
@@ -119,6 +119,7 @@ export default class ProjectConfigs {
 
         const ghostUrl = formData['ghost.url'];
         const ghostAdminKey = formData['ghost.key'];
+        const newsletterTrackLinks = formData['newsletter.track_links'];
         const newsletterCenterTitle = formData['newsletter.center_title'];
         const newsletterShowComments = formData['newsletter.show_comments'];
         const newsletterShowLatestPosts = formData['newsletter.show_latest_posts'];
@@ -145,6 +146,7 @@ export default class ProjectConfigs {
         configs.ghost.key = ghostAdminKey;
 
         // newsletter
+        configs.newsletter.track_links = newsletterTrackLinks === 'on' ?? true;
         configs.newsletter.center_title = newsletterCenterTitle === 'on' ?? false;
         configs.newsletter.show_comments = newsletterShowComments === 'on' ?? true;
         configs.newsletter.show_latest_posts = newsletterShowLatestPosts === 'on' ?? false;

--- a/utils/data/ops/emails_queue.js
+++ b/utils/data/ops/emails_queue.js
@@ -14,9 +14,11 @@ export default class EmailsQueue {
      * @param {number} [delay=10000] - The delay in milliseconds before processing the queue.
      */
     constructor(delay = 10000) {
-        this.delay = delay;
-        this.queue = new Map();
         this.timer = null;
+        this.delay = delay;
+
+        /**@type {Map<string, Set<number>>} */
+        this.queue = new Map();
     }
 
     /**
@@ -56,7 +58,7 @@ export default class EmailsQueue {
      * Internal method to update the file with the queued changes.
      *
      * @param {string} postId - The ID of the post.
-     * @param {number[]} memberIndexes - Array of member indexes to be updated.
+     * @param {Set<number>} memberIndexes - Array of member indexes to be updated.
      */
     async #updateFile(postId, memberIndexes) {
         try {

--- a/utils/data/ops/emails_queue.js
+++ b/utils/data/ops/emails_queue.js
@@ -1,12 +1,12 @@
-import Files from './files.js';
-import BitSet from '../bitset.js';
-import Miscellaneous from '../misc.js';
-import {logDebug, logError, logTags} from '../log/logger.js';
+import Files from '../files.js';
+import BitSet from '../../bitset.js';
+import Miscellaneous from '../../misc.js';
+import {logDebug, logError, logTags} from '../../log/logger.js';
 
 /**
  * A queue class for batching and processing updates to tracking statistics.
  */
-export default class Queue {
+export default class EmailsQueue {
 
     /**
      * Creates a new Queue instance.
@@ -24,7 +24,7 @@ export default class Queue {
      *
      * @param {string} encodedUUID - The base64 encoded UUID consisting of postId and memberIndex.
      */
-    async add(encodedUUID) {
+    add(encodedUUID) {
         const uuid = Miscellaneous.decode(encodedUUID);
         const [postId, memberIndex] = uuid.split('_');
 
@@ -44,7 +44,7 @@ export default class Queue {
     async #processQueue() {
         const updatePromises = [];
         for (const [postId, memberIndexes] of this.queue) {
-            updatePromises.push(this.#updateFile(postId, Array.from(memberIndexes)));
+            updatePromises.push(this.#updateFile(postId, memberIndexes));
         }
 
         await Promise.allSettled(updatePromises);

--- a/utils/data/ops/links_queue.js
+++ b/utils/data/ops/links_queue.js
@@ -12,9 +12,11 @@ export default class LinksQueue {
      * @param {number} [delay=10000] - The delay in milliseconds before processing the queue.
      */
     constructor(delay = 10000) {
-        this.delay = delay;
-        this.queue = new Map();
         this.timer = null;
+        this.delay = delay;
+
+        /** @type {Map<string, Map<string, number>>} */
+        this.queue = new Map();
     }
 
     /**

--- a/utils/data/ops/links_queue.js
+++ b/utils/data/ops/links_queue.js
@@ -1,0 +1,83 @@
+import Files from '../files.js';
+import {logDebug, logError, logTags} from '../../log/logger.js';
+
+/**
+ * A queue class for batching and processing updates to links click tracking statistics.
+ */
+export default class LinksQueue {
+
+    /**
+     * Creates a new Queue instance.
+     *
+     * @param {number} [delay=10000] - The delay in milliseconds before processing the queue.
+     */
+    constructor(delay = 10000) {
+        this.delay = delay;
+        this.queue = new Map();
+        this.timer = null;
+    }
+
+    /**
+     * Adds a link stat update to the queue.
+     *
+     * @param {string} postId - The ID of the post.
+     * @param {string} url - The URL whose count needs to be updated.
+     */
+    add(postId, url) {
+        if (!this.queue.has(postId)) this.queue.set(postId, new Map());
+
+        const postLinks = this.queue.get(postId);
+
+        // Increment the count for the specific link
+        if (!postLinks.has(url)) postLinks.set(url, 1);
+        else {
+            let currentCount = postLinks.get(url);
+            postLinks.set(url, currentCount + 1);
+        }
+
+        // Reset the timer
+        clearTimeout(this.timer);
+        this.timer = setTimeout(() => this.#processQueue(), this.delay);
+    }
+
+    /**
+     * Internal method to process the queued updates.
+     */
+    async #processQueue() {
+        const updatePromises = [];
+
+        // Iterate over each post and its associated links and counts
+        for (const [postId, urlsMap] of this.queue) {
+            updatePromises.push(this.#updateFile(postId, urlsMap));
+        }
+
+        await Promise.allSettled(updatePromises);
+
+        this.queue.clear();
+    }
+
+    /**
+     * Internal method to update the file with the queued changes.
+     *
+     * @param {string} postId - The ID of the post.
+     * @param {Map<string, number>} urlStats - A map of links and their updated click counts.
+     */
+    async #updateFile(postId, urlStats) {
+        try {
+            const post = await Files.get(postId);
+            if (!post) return;
+
+            post.stats.postContentTrackedLinks.forEach(linkObject => {
+                const linkUrl = Object.keys(linkObject)[0];
+                if (urlStats.has(linkUrl)) linkObject[linkUrl] += urlStats.get(linkUrl);
+            });
+
+            const saved = await Files.create(post, true);
+            if (saved) {
+                logDebug(logTags.Stats, `Batched link click tracking updated for post: ${post.title}.`);
+            }
+        } catch (error) {
+            logError(logTags.Stats, error);
+        }
+    }
+}

--- a/utils/models/stats.js
+++ b/utils/models/stats.js
@@ -5,21 +5,24 @@ export default class Stats {
 
     /**
      * Creates an instance of Stats.
-     * 
+     *
      * @param {number} [members] - Count of members who should receive the newsletter.
      * @param {number} [emailsSent=0] - The count of emails sent related to this Post.
      * @param {string} [emailsOpened=''] - The statistics of opened emails for this Post.
      * @param {string} [newsletterStatus='na'] - The status of the post's newsletter.
+     * @param {{[key: string]: number}[]} [postContentTrackedLinks=[]] - The urls that will be tracked when a user clicks on them in the email.
      */
     constructor(
         members = 0,
         emailsSent = 0,
         emailsOpened = '',
         newsletterStatus = 'na',
+        postContentTrackedLinks = []
     ) {
         this.members = members;
         this.emailsSent = emailsSent;
         this.emailsOpened = emailsOpened;
         this.newsletterStatus = newsletterStatus;
+        this.postContentTrackedLinks = postContentTrackedLinks;
     }
 }

--- a/utils/newsletter.js
+++ b/utils/newsletter.js
@@ -115,6 +115,8 @@ export default class Newsletter {
             }));
         }
 
+        postData.trackLinks = customisations.track_links;
+
         return postData;
     }
 
@@ -126,6 +128,7 @@ export default class Newsletter {
      */
     static async renderTemplate(renderingData) {
         let templatePath;
+        const injectUrlTracking = renderingData.trackLinks;
 
         if (await Files.customTemplateExists()) {
             templatePath = Files.customTemplatePath();
@@ -133,7 +136,9 @@ export default class Newsletter {
 
         try {
             const template = await ejs.renderFile(templatePath, renderingData);
-            return await this.#injectUrlTracking(renderingData, template);
+            return injectUrlTracking
+                ? await this.#injectUrlTracking(renderingData, template)
+                : {trackedLinks: [], modifiedHtml: template};
         } catch (error) {
             logError(logTags.Newsletter, error);
             return undefined;
@@ -284,6 +289,8 @@ export default class Newsletter {
         if (customisations.footer_content !== '') {
             preview.footer_content = customisations.footer_content;
         }
+
+        preview.trackLinks = customisations.track_links;
 
         return preview;
     }

--- a/utils/newsletter.js
+++ b/utils/newsletter.js
@@ -1,3 +1,4 @@
+import he from 'he';
 import ejs from 'ejs';
 import path from 'path';
 
@@ -26,17 +27,23 @@ export default class Newsletter {
         }
 
         const fullRenderData = await this.#makeRenderingData(post, ghost);
-        const fullyRenderedTemplate = await this.#renderTemplate(fullRenderData);
+        const {trackedLinks, fullTemplate} = await this.renderTemplate(fullRenderData);
 
         let payWalledTemplate;
         if (post.isPaid) {
             const partialRenderData = this.#removePaidContent(fullRenderData);
-            payWalledTemplate = await this.#renderTemplate(partialRenderData);
+            payWalledTemplate = (await this.renderTemplate(partialRenderData)).modifiedHtml;
+        }
+
+        if (trackedLinks.length > 0) {
+            trackedLinks.forEach(link => {
+                post.stats.postContentTrackedLinks.push({[link]: 0});
+            });
         }
 
         await new NewsletterMailer().send(
             post, subscribers,
-            fullyRenderedTemplate, payWalledTemplate,
+            fullTemplate, payWalledTemplate,
             fullRenderData.newsletter.unsubscribeLink
         );
     }
@@ -55,6 +62,7 @@ export default class Newsletter {
 
         let postData = {
             site: {
+                url: site.url,
                 lang: site.lang,
                 logo: site.logo,
                 title: site.title,
@@ -62,6 +70,7 @@ export default class Newsletter {
                 color: site.accent_color ?? '#ff247c',
             },
             post: {
+                id: post.id,
                 url: post.url,
                 date: post.date,
                 title: post.title,
@@ -109,8 +118,13 @@ export default class Newsletter {
         return postData;
     }
 
-    // Render the ejs template with given data.
-    static async #renderTemplate(renderingData) {
+    /**
+     * Render the newsletter `ejs` template with given data.
+     *
+     * @param renderingData Data to use to render the content.
+     * @returns {Promise<{trackedLinks: string[], modifiedHtml: string}|undefined>}
+     */
+    static async renderTemplate(renderingData) {
         let templatePath;
 
         if (await Files.customTemplateExists()) {
@@ -118,7 +132,8 @@ export default class Newsletter {
         } else templatePath = path.join(process.cwd(), '/views/newsletter.ejs');
 
         try {
-            return await ejs.renderFile(templatePath, renderingData);
+            const template = await ejs.renderFile(templatePath, renderingData);
+            return await this.#injectUrlTracking(renderingData, template);
         } catch (error) {
             logError(logTags.Newsletter, error);
             return undefined;
@@ -138,17 +153,90 @@ export default class Newsletter {
         return renderedPostData;
     }
 
+    // we cannot use the 'ping' attribute to anchor tags,
+    // so we add redirects to track url clicks in email clients.
+    static async #injectUrlTracking(renderingData, renderedPostData) {
+        const ghosler = await ProjectConfigs.ghosler();
+        const pingUrl = `${ghosler.url}/track/link?postId=${renderingData.post.id}&redirect=`;
+
+        const domainsToExclude = [
+            new URL(ghosler.url).host, // current domain
+            new URL('https://static.ghost.org').host, // ghost static resources domain
+        ];
+
+        /**
+         * Exclude featured image urls and urls in feature image caption.
+         */
+        let match;
+        let urlsToExclude = [he.decode(renderingData.post.featuredImage)];
+        const regex = /<a href="(https?:\/\/unsplash\.com[^"]*)"/g;
+        while ((match = regex.exec(renderingData.post.featuredImageCaption)) !== null) {
+            urlsToExclude.push(he.decode(match[1]));
+        }
+
+        /**
+         * Exclude certain urls like -
+         * 1. blog & its logo url,
+         * 2. current post url, comments,
+         * 3. subscription, unsubscribe,
+         * 4. featured image urls from keep reading section (if exists).
+         *
+         * This way we can be sure to track links to other articles as well, example: Keep Reading section.
+         */
+        [
+            renderingData.site.url, renderingData.site.logo,
+            renderingData.post.url, renderingData.post.comments,
+            renderingData.newsletter.subscription,
+            renderingData.newsletter.unsubscribeLink,
+            ...renderingData.post.latestPosts.map(post => post.featuredImage)
+        ].forEach(internalLinks => urlsToExclude.push(he.decode(internalLinks)));
+
+        // Extract the <body> content
+        const bodyContentMatch = renderedPostData.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+        if (!bodyContentMatch) return {trackedLinks: [], modifiedHtml: renderedPostData};
+        let bodyContent = bodyContentMatch[1];
+
+        // Define regex for link holder tags with URLs
+        const tagUrlRegex = /(<(?:a|img)\b[^>]*\b(?:href|src)=")(https?:\/\/[^"]+)(")/gi;
+
+        // Set to store original links
+        let trackedLinks = new Set();
+
+        // Function to process tag URLs
+        const processTagUrl = (match, prefix, url, suffix) => {
+            url = he.decode(url);
+            const urlHost = new URL(url).host;
+
+            if (!domainsToExclude.includes(urlHost) && !urlsToExclude.includes(url)) {
+                trackedLinks.add(url);
+                return `${prefix}${pingUrl}${url}${suffix}`;
+            }
+            return match;
+        };
+
+        // Add ping attribute to tags and store original links
+        bodyContent = bodyContent.replace(tagUrlRegex, processTagUrl);
+
+        // Reconstruct the full HTML with the updated body content
+        const modifiedHtml = renderedPostData.replace(/<body[^>]*>([\s\S]*)<\/body>/i, `<body>${bodyContent}</body>`);
+
+        // Convert the set to an array and return along with modified HTML
+        return {trackedLinks: Array.from(trackedLinks), modifiedHtml};
+    }
+
     // Sample data for preview.
     static async preview() {
         let preview = {
             site: {
                 lang: 'en',
                 color: '#ff247c',
+                url: 'https://bulletin.ghost.io/',
                 logo: 'https://bulletin.ghost.io/content/images/size/w256h256/2021/06/ghost-orb-black-transparent-10--1-.png',
                 title: 'Bulletin',
                 description: 'Thoughts, stories and ideas.'
             },
             post: {
+                id: '60d14faa9e72bc002f16c727',
                 url: 'https://bulletin.ghost.io/welcome',
                 date: '22 June 2021',
                 title: 'Welcome',

--- a/views/dashboard/analytics.ejs
+++ b/views/dashboard/analytics.ejs
@@ -245,6 +245,14 @@
                     </td>
                     <td data-title="Newsletter Status"><%= element.stats.newsletterStatus; %></td>
                     <td data-title="Action">
+                        <% if (element.stats.postContentTrackedLinks.length > 0) { %>
+                            <button type="button"
+                                    style="color: white; background-color: darkgreen; border-radius: 6px; padding: 10px; border: none; cursor: pointer; margin-right: 8px;"
+                                    onclick="window.location='/analytics/links/<%= element.id %>'"
+                            > Links
+                            </button>
+                        <% } %>
+
                         <button type="button"
                                 style="color: white; background-color: darkred; border-radius: 6px; padding: 10px; border: none; cursor: pointer"
                                 onclick="if (confirm('Are you sure to delete this Post analytics?\nClick OK to delete.')) { deletePostAnalytics('<%= element.id %>'); }"

--- a/views/dashboard/analytics.ejs
+++ b/views/dashboard/analytics.ejs
@@ -245,7 +245,9 @@
                     </td>
                     <td data-title="Newsletter Status"><%= element.stats.newsletterStatus; %></td>
                     <td data-title="Action">
-                        <% if (element.stats.postContentTrackedLinks.length > 0) { %>
+                        <% if (typeof element.stats.postContentTrackedLinks !== 'undefined'
+                                && element.stats.postContentTrackedLinks
+                                && element.stats.postContentTrackedLinks.length > 0) { %>
                             <button type="button"
                                     style="color: white; background-color: darkgreen; border-radius: 6px; padding: 10px; border: none; cursor: pointer; margin-right: 8px;"
                                     onclick="window.location='/analytics/links/<%= element.id %>'"

--- a/views/dashboard/links.ejs
+++ b/views/dashboard/links.ejs
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Links - Ghosler</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            margin: 0;
+            font-family: serif;
+            background-color: #f4f4f4
+        }
+
+        .header {
+            padding: 20px;
+            text-align: left;
+            font-size: 1.25rem;
+            background-color: #1b2d48;
+            color: #fff;
+            font-weight: 500
+        }
+
+        h2 {
+            margin: .25em 0;
+            font-size: 1.25rem;
+            font-weight: 700;
+        }
+
+        td,
+        th {
+            padding: 20px;
+            text-align: center;
+            border-bottom: 1px solid #ddd
+        }
+
+        td:first-child,
+        th:first-child {
+            text-align: left
+        }
+
+        th {
+            background-color: #1b2d48
+        }
+
+        table {
+            margin: 20px auto;
+            background-color: #fff;
+            box-shadow: 0 2px 3px rgba(0, 0, 0, .1);
+            border-radius: 10px;
+            width: auto;
+            max-width: 90%;
+            border-spacing: 0
+        }
+
+        thead tr:first-child th:first-child {
+            border-top-left-radius: 10px
+        }
+
+        thead tr:first-child th:last-child {
+            border-top-right-radius: 10px
+        }
+
+        tbody tr:last-child td:first-child {
+            border-bottom-left-radius: 10px
+        }
+
+        tbody tr:last-child td:last-child {
+            border-bottom-right-radius: 10px
+        }
+
+        thead {
+            color: #fff;
+            background-color: #333
+        }
+
+        a {
+            color: #333;
+            text-decoration: none
+        }
+
+        a:hover {
+            text-decoration: underline
+        }
+
+        @media screen and (max-width: 480px) {
+            td,
+            tr {
+                padding: 10px;
+            }
+
+            table {
+                border-radius: 0;
+                background-color: transparent;
+                box-shadow: none
+            }
+
+            .table-container {
+                overflow-x: auto
+            }
+
+            thead {
+                display: none
+            }
+
+            table,
+            tbody,
+            td,
+            tr {
+                display: block;
+                width: auto
+            }
+
+            td {
+                word-break: break-all;
+                white-space: pre-wrap;
+            }
+
+            h2 {
+                margin: .25em 0;
+                font-size: 1.25rem;
+                font-weight: 700
+            }
+
+            tr {
+                margin-bottom: 20px;
+                background-color: #fff;
+                box-shadow: 0 2px 3px rgba(0, 0, 0, .1);
+                border-radius: 8px
+            }
+
+            td {
+                text-align: left;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                border-bottom: 1px solid #ddd
+            }
+
+            tbody tr:last-child td:first-child {
+                border-bottom-left-radius: 0
+            }
+
+            tr td:last-child {
+                border-bottom: none
+            }
+
+            td[data-title]:not([data-title=Link])::before {
+                content: attr(data-title) ": ";
+                font-weight: 700;
+                margin-right: 8px
+            }
+
+        }
+    </style>
+</head>
+
+<body>
+<div class="header">Links - <a href="/" style="text-decoration: none; color: white">Ghosler</a></div>
+<% if (typeof stats === 'undefined' || !stats || !stats.postContentTrackedLinks || stats.postContentTrackedLinks.length === 0) { %>
+    <h2 style="text-align: center; color: #666; margin: 25px;">No links available for this post!</h2>
+<% } else { %>
+    <p style="text-align: center; color: #666; margin: 25px; line-height: 1.5">
+        <strong>Clicks are tracked & incremented<br>everytime they are clicked.</strong>
+    </p>
+
+    <div class="table-container">
+        <table>
+            <thead>
+            <tr>
+                <th>Links</th>
+                <th>Clicks</th>
+            </tr>
+            </thead>
+            <tbody>
+            <% stats.postContentTrackedLinks.forEach(element => { %>
+                <tr>
+                    <% const link = Object.keys(element)[0]; %>
+                    <% const clicks = element[link]; %>
+                    <td data-title="Link"><h4><a href="<%= link; %>" target="_blank"><%= link; %></a></h4></td>
+                    <td data-title="Clicks"><%= clicks; %></td>
+                </tr>
+            <% }); %>
+            </tbody>
+        </table>
+    </div>
+<% } %>
+</body>
+</html>

--- a/views/newsletter.ejs
+++ b/views/newsletter.ejs
@@ -769,20 +769,21 @@
                                         <td align="center"
                                             style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; vertical-align: top; color: #15212A; text-align: center; padding-top: 70px; padding-bottom: 40px;"
                                             valign="top">
-                                            <% if (show_powered_by_ghost) { %> <a href="https://ghost.org/"
-                                                                                  style="color: <%= site.color %>; text-decoration: none; overflow-wrap: anywhere;"
-                                                                                  target="_blank">
-                                                <img alt="Powered by Ghost" border="0" height="30"
-                                                     src="https://static.ghost.org/v4.0.0/images/powered.png"
-                                                     style="border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 142px; height: 30px;"
-                                                     width="142">
-                                            </a>
+                                            <% if (show_powered_by_ghost) { %>
+                                                <a href="https://ghost.org/"
+                                                   style="color: <%= site.color %>; text-decoration: none; overflow-wrap: anywhere;"
+                                                   target="_blank">
+                                                    <img alt="Powered by Ghost" border="0" height="30"
+                                                         src="https://static.ghost.org/v4.0.0/images/powered.png"
+                                                         style="border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 142px; height: 30px;"
+                                                         width="142">
+                                                </a>
                                             <% } %>
                                             <% if (show_powered_by_ghost && show_powered_by_ghosler) { %> <p></p>
                                             <% } %>
                                             <% if (show_powered_by_ghosler) { %> <a
                                                     href="https://github.com/itznotabug/ghosler"
-                                                    style="color: #888; font-family: 'Arial Rounded MT Bold', serif; font-size: 14px; font-weight: 500; text-decoration: none; overflow-wrap: anywhere;"
+                                                    style="color: #1E2023; font-family: 'Arial Rounded MT Bold', serif; font-size: 12px; font-weight: 500; text-decoration: none; overflow-wrap: anywhere;"
                                                     target="_blank" rel="noopener noreferrer">Newsletter Powered by
                                                 <span style="color:<%= site.color %>;">Ghosler️</span>
                                             </a>

--- a/views/partials/settings/customise.ejs
+++ b/views/partials/settings/customise.ejs
@@ -7,7 +7,7 @@
     </div>
 
     <div id="newsletterSettings" style="display: none;">
-        <div class="form-group-row ">
+        <div class="form-group-row">
             <label>Center Title</label>
             <input type="checkbox" name="newsletter.center_title"
             <% if (Boolean(configs.newsletter.center_title)) { %> checked
@@ -15,7 +15,21 @@
             >
         </div>
 
-        <div class="form-group-row ">
+        <div class="form-group-row">
+            <label>Track URL Clicks
+                <span style="font-weight: normal; font-size: 12px; color: #738a94">
+                    <!-- Linking a future PR, hehe. -->
+                    (<a href="https://github.com/itznotabug/ghosler/pull/7" target="_blank"
+                        style="text-decoration: none; color: dodgerblue">See</a> what URLs are tracked)
+                </span>
+            </label>
+            <input type="checkbox" name="newsletter.track_links"
+            <% if (Boolean(configs.newsletter.track_links)) { %> checked
+                    <% } %>
+            >
+        </div>
+
+        <div class="form-group-row">
             <label>Show Comments</label>
             <input type="checkbox" name="newsletter.show_comments"
             <% if (Boolean(configs.newsletter.show_comments)) { %> checked
@@ -23,7 +37,7 @@
             >
         </div>
 
-        <div class="form-group-row ">
+        <div class="form-group-row">
             <label>Show Latest Posts</label>
             <input type="checkbox" name="newsletter.show_latest_posts"
             <% if (Boolean(configs.newsletter.show_latest_posts)) { %> checked
@@ -31,7 +45,7 @@
             >
         </div>
 
-        <div class="form-group-row ">
+        <div class="form-group-row">
             <label>Show Subscription</label>
             <input type="checkbox" name="newsletter.show_subscription"
             <% if (Boolean(configs.newsletter.show_subscription)) { %> checked
@@ -39,7 +53,7 @@
             >
         </div>
 
-        <div class="form-group-row ">
+        <div class="form-group-row">
             <label>Show Featured Image</label>
             <input type="checkbox" name="newsletter.show_featured_image"
             <% if (Boolean(configs.newsletter.show_featured_image)) { %> checked
@@ -47,7 +61,7 @@
             >
         </div>
 
-        <div class="form-group-row ">
+        <div class="form-group-row">
             <label>Show 'Powered by Ghost'</label>
             <input type="checkbox" name="newsletter.show_powered_by_ghost"
             <% if (Boolean(configs.newsletter.show_powered_by_ghost)) { %> checked

--- a/views/partials/settings/customise.ejs
+++ b/views/partials/settings/customise.ejs
@@ -18,8 +18,7 @@
         <div class="form-group-row">
             <label>Track URL Clicks
                 <span style="font-weight: normal; font-size: 12px; color: #738a94">
-                    <!-- Linking a future PR, hehe. -->
-                    (<a href="https://github.com/itznotabug/ghosler/pull/7" target="_blank"
+                    (<a href="https://github.com/itznotabug/ghosler/pull/8" target="_blank"
                         style="text-decoration: none; color: dodgerblue">See</a> what URLs are tracked)
                 </span>
             </label>


### PR DESCRIPTION
This PR adds the ability to track URL clicks in the email. We use a redirect logic to do the tracking.

**What links are tracked -**
1. All links directing to sites outside the Ghost domain are fully tracked, providing insights into user interaction with external content.

2. Partial support for for Internal Ghost Domain Links
    - **Excluded:** 
        - URL of/in the Featured Image and its caption (if found).
        - URLs that navigate the user to current post (View in browser), comments section, subscription page, unsubscribe page.
    - **Supported:** 
        - Inter-article links, including those within the body of the article and in the "Keep Reading" section, are fully supported and tracked.

---
### Limitation -
URLs are tracked using a redirect logic so if your server hosting `Ghosler` goes down or is not available when someone clicks a URL, the redirection would fail & the URL won't go to the actual destination.