### PR TITLE
Webhook + Secret

### DIFF
--- a/config.production.json
+++ b/config.production.json
@@ -10,6 +10,7 @@
   "ghost": {
     "url": "",
     "key": "",
+    "secret": "",
     "version": "v5.0"
   },
   "newsletter": {

--- a/routes/published.js
+++ b/routes/published.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import Post from '../utils/models/post.js';
+import Miscellaneous from '../utils/misc.js';
 import Newsletter from '../utils/newsletter.js';
 import {logDebug, logTags} from '../utils/log/logger.js';
 
@@ -8,6 +9,11 @@ const router = express.Router();
 router.post('/', async (req, res) => {
     if (!req.body || !req.body.post || !req.body.post.current) {
         res.json({message: "Post content seems to be missing!"});
+    }
+
+    const isSecure = await Miscellaneous.isPostSecure(req);
+    if (!isSecure) {
+        return res.status(401).json({message: 'Invalid Authorization'});
     }
 
     const post = Post.make(req.body);

--- a/routes/published.js
+++ b/routes/published.js
@@ -13,7 +13,7 @@ router.post('/', async (req, res) => {
 
     const isSecure = await Miscellaneous.isPostSecure(req);
     if (!isSecure) {
-        return res.status(401).json({message: 'Invalid Authorization'});
+        return res.status(401).json({message: 'Invalid Authorization.'});
     }
 
     const post = Post.make(req.body);

--- a/utils/api/ghost.js
+++ b/utils/api/ghost.js
@@ -148,12 +148,17 @@ export default class Ghost {
         }
 
         const ghost = await this.#ghost();
+        const secret = (await ProjectConfigs.ghost()).secret;
+        if (!secret || secret === '') {
+            return {level: 'error', message: 'Secret is not set or empty or is less than 8 characters.'};
+        }
 
         try {
             await ghost.webhooks.add({
                 name: 'Ghosler Webhook',
                 event: 'post.published',
                 target_url: `${ghosler.url}/published`,
+                secret: secret,
             });
 
             return {level: 'success', message: 'Webhook created successfully.'};

--- a/utils/data/configs.js
+++ b/utils/data/configs.js
@@ -119,6 +119,7 @@ export default class ProjectConfigs {
 
         const ghostUrl = formData['ghost.url'];
         const ghostAdminKey = formData['ghost.key'];
+        const ghostAdminSecret = formData['ghost.secret'];
         const newsletterTrackLinks = formData['newsletter.track_links'];
         const newsletterCenterTitle = formData['newsletter.center_title'];
         const newsletterShowFeedback = formData['newsletter.show_feedback'];
@@ -138,13 +139,18 @@ export default class ProjectConfigs {
         configs.ghosler.auth.user = user;
         if (configs.ghosler.url !== url) configs.ghosler.url = url;
 
-        if (ghostUrl === '' || ghostAdminKey === '') {
-            return {level: 'error', message: 'Ghost URL or Admin API Key is missing.'};
+        if (ghostUrl === '' || ghostAdminKey === '' || ghostAdminSecret === '') {
+            return {level: 'error', message: 'Ghost URL, Admin API Key or Secret is missing.'};
+        }
+
+        if (ghostAdminSecret.toString().length < 8) {
+            return {level: 'error', message: 'Secret should at-least be 8 characters long.'};
         }
 
         // ghost
         configs.ghost.url = ghostUrl;
         configs.ghost.key = ghostAdminKey;
+        configs.ghost.secret = ghostAdminSecret;
 
         // newsletter
         configs.newsletter.track_links = newsletterTrackLinks === 'on' ?? true;

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -132,17 +132,29 @@ export default class Miscellaneous {
     static async isPostSecure(request) {
         const payload = JSON.stringify(request.body);
         const ghostConfigs = await ProjectConfigs.ghost();
-        const signatureWithDate = request.headers['x-ghost-signature'];
+        const signatureWithDateHeader = request.headers['x-ghost-signature'];
 
         // Secret set on Ghosler but not recd. in the request headers.
-        if (ghostConfigs.secret && !signatureWithDate) {
+        if (ghostConfigs.secret && !signatureWithDateHeader) {
             logError(logTags.Express, 'The \'X-Ghost-Signature\' header not found in the request. Did you setup the Secret Key correctly?');
             return false;
         }
 
+        const signatureAndTimeStamp = signatureWithDateHeader.split(', ');
+
         // @see: https://github.com/TryGhost/Ghost/blob/efb2b07c601cd557976bcbe12633f072da5c22a7/ghost/core/core/server/services/webhooks/WebhookTrigger.js#L98
-        const signature = signatureWithDate.split(', ')[0].replace('sha256=', '');
-        if (!signature) return false;
+        const signature = signatureAndTimeStamp[0].replace('sha256=', '');
+        const timeStamp = parseInt(signatureAndTimeStamp[1].replace('t=', ''));
+        if (!signature || isNaN(timeStamp)) {
+            logError(logTags.Express, 'Either the signature or the timestamp in the \'X-Ghost-Signature\' header is not valid or doesn\'t exist.');
+            return false;
+        }
+
+        const maxTimeDiff = 5 * 60 * 1000; // 5 minutes
+        if (Math.abs(Date.now() - timeStamp) > maxTimeDiff) {
+            logError(logTags.Express, 'The timestamp in the \'X-Ghost-Signature\' header exceeds 5 minutes.');
+            return false;
+        }
 
         const expectedSignature = crypto
             .createHmac('sha256', ghostConfigs.secret)

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -28,7 +28,7 @@ export default class Miscellaneous {
         logDebug(logTags.Express, '============================');
         logDebug(logTags.Express, 'View-engine set!');
 
-        expressApp.get('*', async (req, res, next) => {
+        expressApp.all('*', async (req, res, next) => {
             const path = req.path;
             if (['/analytics', '/logs', '/settings', '/password'].some(prefix => path.startsWith(prefix))) {
                 const authenticated = await Miscellaneous.authenticated(req);

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -28,6 +28,8 @@ export default class Miscellaneous {
         logDebug(logTags.Express, '============================');
         logDebug(logTags.Express, 'View-engine set!');
 
+        // the site might be behind a proxy.
+        expressApp.enable('trust proxy');
         expressApp.all('*', async (req, res, next) => {
             const path = req.path;
             if (['/analytics', '/logs', '/settings', '/password'].some(prefix => path.startsWith(prefix))) {

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -1,6 +1,6 @@
+import crypto from 'crypto';
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import crypto from 'node:crypto';
 import Files from './data/files.js';
 import ProjectConfigs from './data/configs.js';
 import {logDebug, logTags} from './log/logger.js';
@@ -119,6 +119,25 @@ export default class Miscellaneous {
      */
     static hash(data) {
         return crypto.createHash('md5').update(data).digest('hex');
+    }
+
+    /**
+     * Validate if the incoming webhook contains valid secret key.
+     *
+     * @param {express.Request} request - The express request object.
+     * @return {Promise<boolean>} True if valid, false otherwise.
+     */
+    static async isPostSecure(request) {
+        const payload = JSON.stringify(request.body);
+        const signature = request.headers['x-ghost-signature'];
+
+        const ghostConfigs = await ProjectConfigs.ghost();
+
+        const expectedSignature = crypto
+            .createHmac('sha256', ghostConfigs.secret)
+            .update(payload).digest('hex');
+
+        return signature === expectedSignature;
     }
 
     /**

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -207,6 +207,13 @@
     </style>
 
     <script>
+        function integrationIdFromAdminKey(secondID) {
+            const lastTwo = secondID.slice(-2);
+            const shiftedValue = parseInt(lastTwo, 16) - 3 /* shift value of 3 */;
+            const shiftedHex = shiftedValue.toString(16).padStart(2, '0');
+            return secondID.slice(0, -2) + shiftedHex;
+        }
+
         function toggleCard(header, contentId) {
             const content = document.getElementById(contentId);
             if (content.style.display === 'none') {
@@ -269,10 +276,14 @@
             mailConfigIndex--;
         }
 
-        // Initialize all cards to be collapsed by default
         window.onload = function () {
             const cardContents = document.querySelectorAll('.cardview > div:not(.card-header)');
             cardContents.forEach((content) => content.style.display = 'none');
+
+            const integrationElement = document.getElementById('integration');
+            const splitKey = '<%= configs.ghost.key.split(':')[0] %>';
+            const integrationId = integrationIdFromAdminKey(splitKey);
+            integrationElement.href = '<%= configs.ghost.url %>/ghost/#/settings/integrations/' + integrationId;
         };
     </script>
 </head>

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -217,14 +217,13 @@
         function generateRandomString(length = 100) {
             let result = '';
             const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
             for (let i = 0; i < length; i++) {
                 result += characters.charAt(Math.floor(Math.random() * characters.length));
             }
 
+            // ID is always same, so we can directly update value.
             document.getElementById('ghost.secret').value = result;
         }
-
 
         function toggleCard(header, contentId) {
             const content = document.getElementById(contentId);

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -214,6 +214,18 @@
             return secondID.slice(0, -2) + shiftedHex;
         }
 
+        function generateRandomString(length = 100) {
+            let result = '';
+            const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+            for (let i = 0; i < length; i++) {
+                result += characters.charAt(Math.floor(Math.random() * characters.length));
+            }
+
+            document.getElementById('ghost.secret').value = result;
+        }
+
+
         function toggleCard(header, contentId) {
             const content = document.getElementById(contentId);
             if (content.style.display === 'none') {
@@ -281,9 +293,9 @@
             cardContents.forEach((content) => content.style.display = 'none');
 
             const integrationElement = document.getElementById('integration');
-            const splitKey = '<%= configs.ghost.key.split(':')[0] %>';
+            const splitKey = '<%= configs.ghost.key.split(':')[0]; %>';
             const integrationId = integrationIdFromAdminKey(splitKey);
-            integrationElement.href = '<%= configs.ghost.url %>/ghost/#/settings/integrations/' + integrationId;
+            integrationElement.href = '<%= configs.ghost.url; %>/ghost/#/settings/integrations/' + integrationId;
         };
     </script>
 </head>

--- a/views/partials/settings/ghost.ejs
+++ b/views/partials/settings/ghost.ejs
@@ -15,5 +15,38 @@
             <label>Admin Key</label>
             <input type="password" value="<%= configs.ghost.key; %>" name="ghost.key" required>
         </div>
+
+        <div class="form-group">
+            <label>Secret Key</label>
+            <input type="password" value="<%= configs.ghost.secret; %>" name="ghost.secret" required>
+            <span style="font-size: 14px; color: #6c757d; line-height: 1.75;">Use something like -
+                        <strong>
+                            <a href="https://www.lastpass.com/features/password-generator#generatorTool"
+                               target="_blank" style="text-decoration: none; color: #DD2222">LastPass
+                            </a></strong>,
+                        <strong>
+                            <a href="https://www.avast.com/en-in/random-password-generator"
+                               target="_blank" style="text-decoration: none; color: #FF7800">Avast
+                            </a></strong>,
+                        <strong>
+                            <a href="https://1password.com/password-generator/"
+                               target="_blank" style="text-decoration: none; color: #0472EC">1Password
+                            </a></strong> or
+                        <strong>
+                            <a href="https://www.dashlane.com/features/password-generator"
+                               target="_blank" style="text-decoration: none; color: #1B815A">Dashlane
+                            </a></strong>
+                        to generate a secure secret key.
+                    <br>
+                    <br>
+                    <strong>Note: Use Max-Length. No Special Characters!</strong>
+                    <br>
+                <strong>To change the Secret, first delete the Webhook from the integration.
+                    Click <a
+                            id="integration" href="<%= configs.ghost.url %>/ghost/#/settings/integrations/"
+                            target="_blank"
+                            style="color: darkred; text-decoration: none;">here</a> for deletion.</strong>
+            </span>
+        </div>
     </div>
 </div>

--- a/views/partials/settings/ghost.ejs
+++ b/views/partials/settings/ghost.ejs
@@ -18,30 +18,14 @@
 
         <div class="form-group">
             <label>Secret Key</label>
-            <input type="password" value="<%= configs.ghost.secret; %>" name="ghost.secret" required>
-            <span style="font-size: 14px; color: #6c757d; line-height: 1.75;">Use something like -
-                        <strong>
-                            <a href="https://www.lastpass.com/features/password-generator#generatorTool"
-                               target="_blank" style="text-decoration: none; color: #DD2222">LastPass
-                            </a></strong>,
-                        <strong>
-                            <a href="https://www.avast.com/en-in/random-password-generator"
-                               target="_blank" style="text-decoration: none; color: #FF7800">Avast
-                            </a></strong>,
-                        <strong>
-                            <a href="https://1password.com/password-generator/"
-                               target="_blank" style="text-decoration: none; color: #0472EC">1Password
-                            </a></strong> or
-                        <strong>
-                            <a href="https://www.dashlane.com/features/password-generator"
-                               target="_blank" style="text-decoration: none; color: #1B815A">Dashlane
-                            </a></strong>
-                        to generate a secure secret key.
+            <input id="ghost.secret" type="password" value="<%= configs.ghost.secret; %>" name="ghost.secret" required>
+            <span style="font-size: 14px; color: #6c757d; line-height: 1.75;">
+                <button type="button" style="background-color: #28a745; color: white; padding: 12px 16px;"
+                        onclick="if (confirm('Are you sure to change the Secret key?\nRemember that you must DELETE the existing webhook first.\n\nClick OK if you\'ve done that & then Click on Save Changes.')) {
+                            generateRandomString();
+                        }">Click to Generate a Secure Key</button>
                     <br>
-                    <br>
-                    <strong>Note: Use Max-Length. No Special Characters!</strong>
-                    <br>
-                <strong>To change the Secret, first delete the Webhook from the integration.
+                <strong style="font-size: 16px;">To use a new Secret, delete the Webhook from the integration first.
                     Click <a
                             id="integration" href="<%= configs.ghost.url %>/ghost/#/settings/integrations/"
                             target="_blank"


### PR DESCRIPTION
This PR adds an extra layer of security when receiving post data via webhook.
**Pre-requisites:** If updating `Ghosler`, make sure to delete the previously existing webhook. A direct, helper button is provided in the settings.

No action is required for a clean install.

---
Additionally, the PR:
- Enables Trust Proxy for Express by default.
- Protect all request by Basic Auth types for admin endpoints.