### PR TITLE
Discourage Search Engines from Indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -40,12 +40,6 @@ export default class Miscellaneous {
         // the site might be behind a proxy.
         expressApp.enable('trust proxy');
 
-        // disable bot crawling, without file.
-        expressApp.get('/robots.txt', (req, res) => {
-            res.type('text/plain');
-            res.send("User-agent: *\nDisallow: /");
-        });
-
         // add no robots header tag to all.
         expressApp.use((_, res, next) => {
             res.header('X-Robots-Tag', 'noindex, nofollow');

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -39,6 +39,22 @@ export default class Miscellaneous {
 
         // the site might be behind a proxy.
         expressApp.enable('trust proxy');
+
+        // disable bot crawling, without file.
+        expressApp.get('/robots.txt', (req, res) => {
+            res.type('text/plain');
+            res.send("User-agent: *\nDisallow: /");
+        });
+
+        // add no robots header tag to all.
+        expressApp.use((_, res, next) => {
+            res.header('X-Robots-Tag', 'noindex, nofollow');
+            next();
+        });
+
+        logDebug(logTags.Express, 'Robots managed!');
+
+        // password protect, ignore a few endpoints.
         expressApp.all('*', async (req, res, next) => {
             const path = req.path;
             const isUnrestrictedPath = /\/login$|\/preview$|\/track/.test(path);


### PR DESCRIPTION
This PR adds the basic `deny all` robots.txt endpoint and a `X-Robots-Tag` header to all endpoints.

---
**Note: It is up to the search engines to honor his request.**