### PR TITLE
Ability to Ignore a Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Pre-requisites: `Node 18^` & `pm2` installed.
       Upon clicking **Save Changes**, Ghosler will automatically create a new `Webhook` in the Ghost Integration (if it
       doesn't already exist).
       This webhook enables **Ghosler** to receive information about posts when they are published.
+4. **Only publishing a Post**: If you want to only publish a post & not send it via email, just add the `#GhoslerIgnore`
+   tag to a post. The internal tag is created for you on the initial setup.
 
 Now as soon as you publish your Post, it will be sent to your Subscribers who have enabled receiving emails.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.84",
+  "version": "0.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.84",
+      "version": "0.86",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.1",
         "@tryghost/admin-api": "^1.13.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.84",
+  "version": "0.86",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/routes/published.js
+++ b/routes/published.js
@@ -8,12 +8,18 @@ const router = express.Router();
 
 router.post('/', async (req, res) => {
     if (!req.body || !req.body.post || !req.body.post.current) {
-        res.json({message: "Post content seems to be missing!"});
+        res.json({message: 'Post content seems to be missing!'});
     }
 
+    // check if the request is authenticated.
     const isSecure = await Miscellaneous.isPostSecure(req);
     if (!isSecure) {
         return res.status(401).json({message: 'Invalid Authorization.'});
+    }
+
+    // check if contains the ignore tag.
+    if (Post.containsIgnoreTag(req.body)) {
+        return res.json({message: 'Post contains `ghosler_ignore` tag, ignoring.'});
     }
 
     const post = Post.make(req.body);
@@ -21,10 +27,10 @@ router.post('/', async (req, res) => {
     logDebug(logTags.Newsletter, 'Post received via webhook.');
 
     if (!created) {
-        res.json({message: "The post data could not be saved, or emails for this post have already been sent."});
+        res.json({message: 'The post data could not be saved, or emails for this post have already been sent.'});
     } else {
         Newsletter.send(post).then(); // schedule sending.
-        res.json({message: "Newsletter will be sent shortly."});
+        res.json({message: 'Newsletter will be sent shortly.'});
     }
 });
 

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -20,9 +20,10 @@ router.post('/', async (req, res) => {
 
     if (configs.ghost.url && configs.ghost.key) {
         const ghost = new Ghost();
-        const response = await ghost.registerWebhook();
+        const tagResponse = await ghost.registerIgnoreTag();
+        const webhookResponse = await ghost.registerWebhook();
 
-        if (response.level === 'error') {
+        if (tagResponse.level === 'error' || webhookResponse.level === 'error') {
             level = response.level;
             message = response.message;
         }

--- a/utils/models/post.js
+++ b/utils/models/post.js
@@ -89,6 +89,18 @@ export default class Post {
     }
 
     /**
+     * Check if we should ignore the post based on the tags it contains.
+     *
+     * @param payload - The payload to check against.
+     * @returns {boolean} True if the internal tag is found, false otherwise.
+     */
+    static containsIgnoreTag(payload) {
+        // it is always an array.
+        const postTags = payload.post.current.tags;
+        return postTags.some(tag => tag.slug === 'ghosler_ignore');
+    }
+
+    /**
      * Save the data when first received from the webhook.
      *
      * @returns {Promise<boolean>} A promise that resolves to true if file creation succeeded, false otherwise.


### PR DESCRIPTION
This PR adds the ability to ignore a post when published. The tag is created for the user on initial setup or on a settings save if updating.

---
#### How does it work?
Simply add the `#GhoslerIgnore` internal tag to a post that you do not want to send as email & it will be ignored by Ghosler.