### PR TITLE
Fix Image Caption Contains `null` as Text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.91",
+  "version": "0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.91",
+      "version": "0.92",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.2",
         "@tryghost/admin-api": "^1.13.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.91",
+  "version": "0.92",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/views/newsletter.ejs
+++ b/views/newsletter.ejs
@@ -993,7 +993,10 @@
                                                  style="border-radius: 5px;  border: none; -ms-interpolation-mode: bicubic; max-width: 100%;"
                                                  width="600">
                                         </td>
-                                    </tr><% if (post.featuredImageCaption) { %>
+                                    </tr>
+
+                                    <!-- I saw `null` as a text for `post.featuredImageCaption`, weird. -->
+                                    <% if (post.featuredImageCaption && post.featuredImageCaption !== 'null') { %>
                                         <tr>
                                             <td align="center"
                                                 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; width: 100%; padding-bottom: 30px; text-align: center; font-size: 13px; color: #738a94;"

--- a/views/newsletter.ejs
+++ b/views/newsletter.ejs
@@ -996,7 +996,7 @@
                                     </tr>
 
                                     <!-- I saw `null` as a text for `post.featuredImageCaption`, weird. -->
-                                    <% if (post.featuredImageCaption && post.featuredImageCaption !== 'null') { %>
+                                    <% if (post.featuredImageCaption && post.featuredImageCaption.replace(/\s+/g, '') !== 'null') { %>
                                         <tr>
                                             <td align="center"
                                                 style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; width: 100%; padding-bottom: 30px; text-align: center; font-size: 13px; color: #738a94;"


### PR DESCRIPTION
This PR fixes the issue where if, for some reason, the incoming Featured Image Caption is `null` as a text, it was still shown below the Feature Image, which doesn't look good.