### PR TITLE
Fix `Null` URLs Tracking Exclusion Crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.92",
+  "version": "0.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.92",
+      "version": "0.93",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.2",
         "@tryghost/admin-api": "^1.13.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.92",
+  "version": "0.93",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/utils/newsletter.js
+++ b/utils/newsletter.js
@@ -213,9 +213,8 @@ export default class Newsletter {
             renderingData.newsletter.unsubscribeLink,
             renderingData.newsletter.feedbackLikeLink,
             renderingData.newsletter.feedbackDislikeLink,
-            // featuredImage can be null, so we should to filter them.
-            ...renderingData.post.latestPosts.filter(post => post.featuredImage).map(post => post.featuredImage)
-        ].forEach(internalLinks => urlsToExclude.push(he.decode(internalLinks)));
+            ...renderingData.post.latestPosts.map(post => post.featuredImage)
+        ].forEach(linkToTrack => linkToTrack && urlsToExclude.push(he.decode(linkToTrack)));
 
         const trackedLinks = new Set();
         const $ = cheerio.load(renderedPostData);


### PR DESCRIPTION
This PR fixes the #36 issue that is caused due to any of the listed `URL` being `null`.