### PR TITLE
Fix: #45

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,7 @@ public/styles/tailwind.css
 
 # installer
 docker-install.sh
+
+# local, debug config files
+configuration/config.debug.json
+configuration/config.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 
 # debug configuration
 configuration/config.debug.json
+configuration/config.local.json
 
 # custom template used for tests
 custom-template.ejs

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Now as soon as you publish your Post, it will be sent to your Subscribers who ha
 Ghosler defaults to using a local configuration file, `config.local.json`, if it exists. The structure of this file is
 identical to that in [config.production.json](./configuration/config.production.json) file.
 
+**Note: `config.local.json` should be placed inside the `configuration` directory.**
+
 **Local Builds:**
 Make sure to execute -
 
@@ -158,7 +160,8 @@ cloudflared tunnel --url http://localhost:2369
 ```
 
 This command will initialize a tunnel and return a URL that you can use to test.\
-For more info, see - [TryCloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/).
+For more info,
+see - [TryCloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/).
 
 ### Custom Template
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now as soon as you publish your Post, it will be sent to your Subscribers who ha
 
 ### Testing Configurations
 
-Ghosler defaults to using a debug configuration file, `config.debug.json`, if it exists. The structure of this file is
+Ghosler defaults to using a local configuration file, `config.local.json`, if it exists. The structure of this file is
 identical to that in [config.production.json](./configuration/config.production.json) file.
 
 **Local Builds:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.95",
+  "version": "0.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.95",
+      "version": "0.96",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.2",
         "@tryghost/admin-api": "^1.13.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.95",
+  "version": "0.96",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/utils/data/configs.js
+++ b/utils/data/configs.js
@@ -290,8 +290,7 @@ export default class ProjectConfigs {
     static async #getConfigFilePath() {
         const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-        // TODO: this change would require a migration via ghosler-cli.
-        const debugConfigPath = path.resolve(__dirname, '../../configuration/config.debug.json');
+        const debugConfigPath = path.resolve(__dirname, '../../configuration/config.local.json');
         const prodConfigPath = path.resolve(__dirname, '../../configuration/config.production.json');
 
         try {


### PR DESCRIPTION
This PR fixes #45.
I accidentally pushed my credentials via `config.debug.json` up to docker hub.

The credentials are revoked & rotated and would no longer work used in the config file. In order to avoid confusion for folks who might not know about this issue, I've changed the implementation a bit to now use `config.local.json` instead of `config.debug.json` which anyway fits the need & is now added to `.dockerignore` too.

---
Thanks @viriatusX for a prompt report on this issue!