### PR TITLE
Fix `ERR_INVALID_URL`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghosler",
-  "version": "0.96",
+  "version": "0.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghosler",
-      "version": "0.96",
+      "version": "0.97",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.2",
         "@tryghost/admin-api": "^1.13.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghosler",
   "description": "Send newsletter emails to your members, using your own email credentials!",
-  "version": "0.96",
+  "version": "0.97",
   "private": true,
   "main": "app.js",
   "type": "module",

--- a/utils/newsletter.js
+++ b/utils/newsletter.js
@@ -234,10 +234,18 @@ export default class Newsletter {
             let elementUrl = $(element).attr(tag);
             if (elementUrl === '#' || !elementUrl) return;
 
-            elementUrl = he.decode(elementUrl);
-            const urlHost = new URL(elementUrl).host;
+            /** @type {string | null} */
+            let urlHost = null;
 
-            if (!domainsToExclude.includes(urlHost) && !urlsToExclude.includes(elementUrl)) {
+            elementUrl = he.decode(elementUrl);
+
+            try {
+                urlHost = new URL(elementUrl).host;
+            } catch (error) {
+                logError(logTags.Newsletter, Error(`Invalid URL found: ${elementUrl}, ${error.stack}.`));
+            }
+
+            if (urlHost && !domainsToExclude.includes(urlHost) && !urlsToExclude.includes(elementUrl)) {
                 trackedLinks.add(elementUrl);
                 $(element).attr(tag, `${pingUrl}${elementUrl}`);
             }


### PR DESCRIPTION
This PR logs an `error` instead of crashing the app when an invalid url is found while extracting its host.