### PR TITLE
Allow Insecure Mail Transport

### DIFF
--- a/utils/data/configs.js
+++ b/utils/data/configs.js
@@ -228,7 +228,7 @@ export default class ProjectConfigs {
         configs.custom_template.enabled = customTemplateEnabled === 'on' ?? false;
 
         // mail configurations
-        configs.mail = [...email.map(({batch_size, delay_per_batch, auth_user, auth_pass, ...rest}) => {
+        configs.mail = [...email.map(({batch_size, delay_per_batch, auth_user, auth_pass, secure, ...rest}) => {
             return {
                 ...rest,
                 batch_size: parseInt(batch_size),
@@ -236,7 +236,8 @@ export default class ProjectConfigs {
                 auth: {
                     user: auth_user,
                     pass: auth_pass
-                }
+                },
+                secure: secure === 'on' ? true : false
             };
         })];
 

--- a/utils/mail/mailer.js
+++ b/utils/mail/mailer.js
@@ -188,12 +188,25 @@ export default class NewsletterMailer {
      * @returns {Promise<*>} - The configured transporter.
      */
     async #transporter(mailConfig) {
-        return nodemailer.createTransport({
-            secure: true,
-            host: mailConfig.host,
-            port: mailConfig.port,
-            auth: {user: mailConfig.auth.user, pass: mailConfig.auth.pass}
-        });
+        // Destructure from mailConfig, defaulting secure to true if not specified
+        const { secure = true, host, port, auth } = mailConfig;
+    
+        // Initialize transport options
+        const transportOptions = {
+            secure,
+            host,
+            port
+        };
+    
+        // Conditionally add auth if both user and pass are provided
+        if (auth && auth.user && auth.pass) {
+            transportOptions.auth = {
+                user: auth.user,
+                pass: auth.pass
+            };
+        }
+    
+        return nodemailer.createTransport(transportOptions);
     }
 
     /**

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -68,7 +68,7 @@
                         <div class="flex items-center">
                             <input type="checkbox" class="form-checkbox h-4 w-4 text-blue-600 rounded border-gray-600 mr-2"
                                     id="email[${mailConfigIndex}][secure]" name="email[${mailConfigIndex}][secure]"
-                                <% if (Boolean(configs.mail[${mailConfigIndex}].secure)) { %> checked
+                                <% if (Boolean(configs.mail[configs.mail.length - 1].secure)) { %> checked
                                        <% } %>
                                 >
                             <label for="email[${mailConfigIndex}][secure]" class="text-gray-300">Secure</label>

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -46,7 +46,7 @@
                 <div id="mailConfigInner${mailConfigIndex}" class="mt-4" style="display: none;">
                     <div class="form-group mb-4">
                         <label for="email[${mailConfigIndex}][reply_to]" class="block text-gray-300 mb-1">Reply To</label>
-                        <input type="text" placeholder="'Author' <author@ghost.org> [Optional]" id="email[${mailConfigIndex}][reply_to]" name="email[${mailConfigIndex}][reply_to]" required class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
+                        <input type="text" placeholder="'Author' <author@ghost.org> [Optional]" id="email[${mailConfigIndex}][reply_to]" name="email[${mailConfigIndex}][reply_to]" class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
                     </div>
 
                     <div class="form-group mb-4">
@@ -65,13 +65,24 @@
                     </div>
 
                     <div class="form-group mb-4">
+                        <div class="flex items-center">
+                            <input type="checkbox" class="form-checkbox h-4 w-4 text-blue-600 rounded border-gray-600 mr-2"
+                                    id="email[${mailConfigIndex}][secure]" name="email[${mailConfigIndex}][secure]"
+                                <% if (Boolean(configs.mail[${mailConfigIndex}].secure)) { %> checked
+                                       <% } %>
+                                >
+                            <label for="email[${mailConfigIndex}][secure]" class="text-gray-300">Secure</label>
+                        </div>
+                    </div>
+
+                    <div class="form-group mb-4">
                         <label for="email[${mailConfigIndex}][auth_user]" class="block text-gray-300 mb-1">Auth User</label>
-                        <input type="text" placeholder="Email Username" id="email[${mailConfigIndex}][auth_user]" name="email[${mailConfigIndex}][auth_user]" required class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
+                        <input type="text" placeholder="Email Username" id="email[${mailConfigIndex}][auth_user]" name="email[${mailConfigIndex}][auth_user]" class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
                     </div>
 
                     <div class="form-group mb-4">
                         <label id="email[${mailConfigIndex}][auth_pass]" class="block text-gray-300 mb-1">Auth Password</label>
-                        <input type="password" placeholder="Email Password" id="email[${mailConfigIndex}][auth_pass]" name="email[${mailConfigIndex}][auth_pass]" required class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
+                        <input type="password" placeholder="Email Password" id="email[${mailConfigIndex}][auth_pass]" name="email[${mailConfigIndex}][auth_pass]" class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white" />
                     </div>
 
                     <div class="form-group mb-4">

--- a/views/partials/settings/mail.ejs
+++ b/views/partials/settings/mail.ejs
@@ -60,7 +60,7 @@
                             <div class="flex items-center">
                                 <input type="checkbox" class="form-checkbox h-4 w-4 text-blue-600 rounded border-gray-600 mr-2"
                                         id="email[<%= index; %>][secure]" name="email[<%= index; %>][secure]"
-                                    <% if (Boolean(configs.mail[<%= index; %>].secure)) { %> checked
+                                    <% if (Boolean(configs.mail[index].secure)) { %> checked
                                        <% } %>
                                     >
                                 <label for="email[<%= index; %>][secure]" class="text-gray-300">Secure</label>

--- a/views/partials/settings/mail.ejs
+++ b/views/partials/settings/mail.ejs
@@ -28,7 +28,7 @@
                                 To</label>
                             <input type="text" placeholder="'Author' <author@ghost.org> [Optional]"
                                    id="email[<%= index; %>][reply_to]"
-                                   name="email[<%= index; %>][reply_to]" value="<%= config.reply_to; %>" required
+                                   name="email[<%= index; %>][reply_to]" value="<%= config.reply_to; %>"
                                    class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white">
                         </div>
 
@@ -57,11 +57,22 @@
                         </div>
 
                         <div class="form-group mb-4">
+                            <div class="flex items-center">
+                                <input type="checkbox" class="form-checkbox h-4 w-4 text-blue-600 rounded border-gray-600 mr-2"
+                                        id="email[<%= index; %>][secure]" name="email[<%= index; %>][secure]"
+                                    <% if (Boolean(configs.mail[<%= index; %>].secure)) { %> checked
+                                       <% } %>
+                                    >
+                                <label for="email[<%= index; %>][secure]" class="text-gray-300">Secure</label>
+                            </div>
+                        </div>
+
+                        <div class="form-group mb-4">
                             <label for="email[<%= index; %>][auth_user]" class="block text-gray-300 mb-1">Auth
                                 User</label>
                             <input type="text" placeholder="Email Username"
                                    id="email[<%= index; %>][auth_user]"
-                                   name="email[<%= index; %>][auth_user]" value="<%= config.auth.user; %>" required
+                                   name="email[<%= index; %>][auth_user]" value="<%= config.auth.user; %>"
                                    class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white">
                         </div>
 
@@ -70,7 +81,7 @@
                                 Password</label>
                             <input type="password" placeholder="Email Password"
                                    id="email[<%= index; %>][auth_pass]"
-                                   name="email[<%= index; %>][auth_pass]" value="<%= config.auth.pass; %>" required
+                                   name="email[<%= index; %>][auth_pass]" value="<%= config.auth.pass; %>"
                                    class="shadow appearance-none border border-gray-600 rounded w-full py-2 px-3 bg-gray-700 text-white">
                         </div>
 


### PR DESCRIPTION
Changed the transport builder to be more flexible.

> Defaults to secure = true if mail.secure is not specified
> Does not require auth to be specified if not needed

This fixes the issue revealed in #54 