### PR TITLE
Enable Hosting Ghosler at a Subdirectory

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ import analytics from './routes/analytics.js';
 import newsletters from './routes/newsletters.js';
 
 const expressApp = express();
-Miscellaneous.setup(expressApp).then();
+await Miscellaneous.setup(expressApp);
 
 // define routes
 logDebug('Express', 'Setting routes...');

--- a/app.js
+++ b/app.js
@@ -18,18 +18,6 @@ import newsletters from './routes/newsletters.js';
 const expressApp = express();
 Miscellaneous.setup(expressApp).then();
 
-// Middleware to provide constants to all views
-expressApp.use(async (req, res, next) => {
-    try {
-        const configs = await ProjectConfigs.all();
-	res.locals.ghoslerUrl = configs.ghosler.url || '';
-    } catch (error) {
-        res.locals.ghoslerUrl = '';
-        logDebug(logTags.Express, 'Error loading configuration: ' + error.message);
-    }
-    next();
-});
-
 // define routes
 logDebug('Express', 'Setting routes...');
 expressApp.use(track);

--- a/app.js
+++ b/app.js
@@ -18,6 +18,18 @@ import newsletters from './routes/newsletters.js';
 const expressApp = express();
 Miscellaneous.setup(expressApp).then();
 
+// Middleware to provide constants to all views
+expressApp.use(async (req, res, next) => {
+    try {
+        const configs = await ProjectConfigs.all();
+	res.locals.ghoslerUrl = configs.ghosler.url || '';
+    } catch (error) {
+        res.locals.ghoslerUrl = '';
+        logDebug(logTags.Express, 'Error loading configuration: ' + error.message);
+    }
+    next();
+});
+
 // define routes
 logDebug('Express', 'Setting routes...');
 expressApp.use(track);

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -40,11 +40,13 @@ router.post('/template', async (req, res) => {
 router.post('/', async (req, res) => {
     const formData = req.body;
 
-    let fullUrl = `${req.protocol}://${req.get('Host')}${req.originalUrl.split("/settings")[0]}`;
+    let fullUrl = new URL(`${req.protocol}://${req.get('Host')}${req.originalUrl}`);
     if (req.get('Referer')) {
-        fullUrl = req.get('Referer').split("/settings")[0];
+        fullUrl = new URL(req.get('Referer'));
     }
-    formData['ghosler.url'] = fullUrl;
+    fullUrl.pathname = fullUrl.pathname.split('/settings')[0];
+    fullUrl.search = ''; // drops any query parameters
+    formData['ghosler.url'] = fullUrl.toString();
 
     const result = await ProjectConfigs.update(formData);
     const configs = await ProjectConfigs.all();

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -46,7 +46,9 @@ router.post('/', async (req, res) => {
     }
     fullUrl.pathname = fullUrl.pathname.split('/settings')[0];
     fullUrl.search = ''; // drops any query parameters
-    formData['ghosler.url'] = fullUrl.toString();
+    fullUrl.pathname = fullUrl.pathname.replace(/\/+/g, '/'); // combine repeated forward slashes in path
+    let normalizedUrl = fullUrl.href.replace(/\/$/, '').toString(); // drop a trailing slash
+    formData['ghosler.url'] = normalizedUrl;
 
     const result = await ProjectConfigs.update(formData);
     const configs = await ProjectConfigs.all();

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -39,7 +39,7 @@ router.post('/template', async (req, res) => {
 
 router.post('/', async (req, res) => {
     const formData = req.body;
-    formData['ghosler.url'] = req.protocol + '://' + req.hostname;
+    formData['ghosler.url'] = req.protocol + '://' + req.get('Host') + req.originalUrl.split("/settings")[0];
 
     const result = await ProjectConfigs.update(formData);
     const configs = await ProjectConfigs.all();

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -39,7 +39,12 @@ router.post('/template', async (req, res) => {
 
 router.post('/', async (req, res) => {
     const formData = req.body;
-    formData['ghosler.url'] = req.protocol + '://' + req.get('Host') + req.originalUrl.split("/settings")[0];
+
+    let fullUrl = `${req.protocol}://${req.get('Host')}${req.originalUrl.split("/settings")[0]}`;
+    if (req.get('Referer')) {
+        fullUrl = req.get('Referer').split("/settings")[0];
+    }
+    formData['ghosler.url'] = fullUrl;
 
     const result = await ProjectConfigs.update(formData);
     const configs = await ProjectConfigs.all();

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -34,7 +34,7 @@ export default class Miscellaneous {
         }));
 
         // Safeguard
-        Files.makeFilesDir().then();
+        await Files.makeFilesDir();
 
         logDebug(logTags.Express, '============================');
         logDebug(logTags.Express, 'View-engine set!');
@@ -51,13 +51,8 @@ export default class Miscellaneous {
             res.header('X-Robots-Tag', 'noindex, nofollow');
 
             // provide ghosler.url to every view.
-            try {
-                const ghosler = await ProjectConfigs.ghosler();
-                res.locals.ghoslerUrl = ghosler.url || '';
-            } catch {
-                res.locals.ghoslerUrl = '';
-                logDebug(logTags.Express, 'Error loading ghosler.url config: ' + error.message);
-            }
+            const ghosler = await ProjectConfigs.ghosler();
+            res.locals.ghoslerUrl = ghosler.url || '';
 
             // finally move ahead.
             next();

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -43,12 +43,21 @@ export default class Miscellaneous {
         expressApp.enable('trust proxy');
 
         // add common data for response.
-        expressApp.use((_, res, next) => {
+        expressApp.use(async (_, res, next) => {
             // add project version info for all render pages.
             res.locals.version = ProjectConfigs.ghoslerVersion;
 
             // add no robots header tag to all.
             res.header('X-Robots-Tag', 'noindex, nofollow');
+
+            // provide ghosler.url to every view.
+            try {
+                const ghosler = await ProjectConfigs.ghosler();
+                res.locals.ghoslerUrl = ghosler.url || '';
+            } catch {
+                res.locals.ghoslerUrl = '';
+                logDebug(logTags.Express, 'Error loading ghosler.url config: ' + error.message);
+            }
 
             // finally move ahead.
             next();

--- a/views/dashboard/analytics.ejs
+++ b/views/dashboard/analytics.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Analytics - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -13,7 +13,7 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
             <li>Analytics</li>
         </ul>
@@ -212,7 +212,7 @@
 
 <script>
     function deletePostAnalytics(postId) {
-        fetch(`/analytics/delete/${postId}`, {method: 'POST'})
+        fetch(`<%= ghoslerUrl %>/analytics/delete/${postId}`, {method: 'POST'})
             .then(() => window.location.reload())
             .catch((error) => console.log(error));
     }
@@ -222,7 +222,7 @@
 
         let location = 'analytics/details';
         if (element.stats.newsletterStatus === 'Unsent') location = 'newsletters'
-        window.location = `/${location}/${element.id}`
+        window.location = `<%= ghoslerUrl %>/${location}/${element.id}`
     }
 
     function openModal(modalId) {

--- a/views/dashboard/details.ejs
+++ b/views/dashboard/details.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Details - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
     <script>
         window.onload = function () {
             const sentiment = '<%= parseInt(postSentiments.sentiment) ?? 'N/A'; %>';
@@ -34,9 +34,9 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
-            <li><a href="/analytics" class="hover:text-white">Analytics</a></li>
+            <li><a href="<%= ghoslerUrl %>/analytics" class="hover:text-white">Analytics</a></li>
             <li><span class="mx-2">></span></li>
             <li><%= post ? post.title : 'NA'; %></li>
         </ul>

--- a/views/dashboard/logs.ejs
+++ b/views/dashboard/logs.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Logs - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -15,9 +15,9 @@
 
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
-            <li><a href="/logs" class="hover:text-white">Logs</a></li>
+            <li><a href="<%= ghoslerUrl %>/logs" class="hover:text-white">Logs</a></li>
             <li><span class="mx-2">></span></li>
             <li><%= logLevel %></li>
         </ul>
@@ -30,7 +30,7 @@
                 <button type="button"
                         class="px-3 py-1 bg-red-800 hover:bg-red-900 text-white font-bold rounded transition duration-300"
                         onclick="if (confirm('Do you really want to delete/clear these logs? Click OK to delete.')) {
-                                window.location = '/logs/clear/<%= logLevel.toLowerCase() %>'
+                                window.location = '<%= ghoslerUrl %>/logs/clear/<%= logLevel.toLowerCase() %>'
                                 }">
                     Clear
                 </button>

--- a/views/dashboard/newsletters.ejs
+++ b/views/dashboard/newsletters.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Newsletters - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -13,7 +13,7 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
             <li>Newsletters</li>
         </ul>
@@ -48,7 +48,7 @@
                             <div class="text-sm text-gray-500 py-1"><%= element.description; %></div>
                         </td>
                         <td class="text-center px-6 py-4 relative">
-                            <form action="/newsletters/send" method="post">
+                            <form action="<%= ghoslerUrl %>/newsletters/send" method="post">
                                 <input type="hidden" name="postId" value="<%= post.id %>">
                                 <input type="hidden" name="newsletterId" value="<%= element.id %>">
                                 <input type="hidden" name="newsletterName" value="<%= element.name %>">
@@ -77,7 +77,7 @@
 
                     <div class="pt-4">
                         <div class="space-x-2">
-                            <form action="/newsletters/send" method="post">
+                            <form action="<%= ghoslerUrl %>/newsletters/send" method="post">
                                 <input type="hidden" name="postId" value="<%= post.id %>">
                                 <input type="hidden" name="newsletterId" value="<%= element.id %>">
                                 <input type="hidden" name="newsletterName" value="<%= element.name %>">
@@ -99,7 +99,7 @@
 <%- include('../partials/common/footer.ejs') %>
 
 <% if (typeof level !== 'undefined') { %>
-    <script>setTimeout(() => window.location = '/analytics', 1750);</script>
+    <script>setTimeout(() => window.location = '<%= ghoslerUrl %>/analytics', 1750);</script>
 <% } %>
 
 </body>

--- a/views/dashboard/password.ejs
+++ b/views/dashboard/password.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Password - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -13,9 +13,9 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
-            <li><a href="/settings" class="hover:text-white">Settings</a></li>
+            <li><a href="<%= ghoslerUrl %>/settings" class="hover:text-white">Settings</a></li>
             <li><span class="mx-2">></span></li>
             <li>Profile Password</li>
         </ul>
@@ -23,7 +23,7 @@
 
     <%- include('../partials/common/message.ejs') %>
 
-    <form action="/password" method="post" class="max-w-lg mx-auto bg-gray-800 rounded-lg shadow-md p-8">
+    <form action="<%= ghoslerUrl %>/password" method="post" class="max-w-lg mx-auto bg-gray-800 rounded-lg shadow-md p-8">
         <div class="mb-6">
             <label for="current-password" class="block text-gray-300 font-bold mb-2">Current Password</label>
             <input type="password" id="current-password" name="ghosler.auth.pass" required

--- a/views/dashboard/settings.ejs
+++ b/views/dashboard/settings.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Settings - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
     <script>
         function integrationIdFromAdminKey(secondID) {
             const lastTwo = secondID.slice(-2);
@@ -122,7 +122,7 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
             <li>Settings</li>
         </ul>
@@ -134,7 +134,7 @@
 
         <%- include('../partials/common/message.ejs') %>
 
-        <form action="/settings" method="post">
+        <form action="<%= ghoslerUrl %>/settings" method="post">
 
             <!-- Profile -->
             <%- include('../partials/settings/profile.ejs') %>

--- a/views/dashboard/upload-template.ejs
+++ b/views/dashboard/upload-template.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Upload Template - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -13,9 +13,9 @@
 <main class="container mx-auto p-6 flex-grow">
     <nav class="text-gray-400 mb-4">
         <ul class="flex">
-            <li><a href="/" class="hover:text-white">Home</a></li>
+            <li><a href="<%= ghoslerUrl %>/" class="hover:text-white">Home</a></li>
             <li><span class="mx-2">></span></li>
-            <li><a href="/settings" class="hover:text-white">Settings</a></li>
+            <li><a href="<%= ghoslerUrl %>/settings" class="hover:text-white">Settings</a></li>
             <li><span class="mx-2">></span></li>
             <li>Upload Custom Template</li>
         </ul>
@@ -23,7 +23,7 @@
 
     <%- include('../partials/common/message.ejs') %>
 
-    <form action="/settings/template" method="post" enctype="multipart/form-data"
+    <form action="<%= ghoslerUrl %>/settings/template" method="post" enctype="multipart/form-data"
           class="max-w-lg mx-auto bg-gray-800 rounded-lg shadow-md p-8">
         <div class="mb-8">
             <!-- Upload a Custom Template -->
@@ -46,7 +46,7 @@
             </button>
 
             <% if (customTemplateExists) { %>
-                <a href="/settings/template/download/custom_template" type="submit"
+                <a href="<%= ghoslerUrl %>/settings/template/download/custom_template" type="submit"
                    class="bg-blue-600 hover:bg-blue-700 mb-4 text-white font-bold py-2 px-4 rounded">
                     Download Current Template
                 </a>

--- a/views/errors/404.ejs
+++ b/views/errors/404.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Not Found - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -20,7 +20,7 @@
     <p>
         Please check the URL for any typos or
         <br>return to the
-        <a href="/" class="text-blue-400 hover:text-blue-500">homepage</a> to find your way.
+        <a href="<%= ghoslerUrl %>/" class="text-blue-400 hover:text-blue-500">homepage</a> to find your way.
     </p>
 </main>
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Home - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="<%= ghoslerURL %>/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Home - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerURL %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -22,7 +22,7 @@
                 <h3 class="text-lg font-bold text-gray-300 mb-4">Manage Your Settings</h3>
                 <p class="text-gray-400 mb-4">Adjust your overall & newsletter settings for optimal experience.</p>
             </div>
-            <a href="/settings"
+            <a href="<%= ghoslerUrl %>/settings"
                class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-300">Settings</a>
         </div>
 
@@ -32,7 +32,7 @@
                 <h3 class="text-lg font-bold text-gray-300 mb-4">Analytics Dashboard</h3>
                 <p class="text-gray-400 mb-4">Explore comprehensive analytics for your newsletter.</p>
             </div>
-            <a href="/analytics"
+            <a href="<%= ghoslerUrl %>/analytics"
                class="inline-block bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded transition duration-300">Analytics</a>
         </div>
 
@@ -42,7 +42,7 @@
                 <h3 class="text-lg font-bold text-gray-300 mb-4">Debug Logs</h3>
                 <p class="text-gray-400 mb-4">Check debug level logs for debugging or finding certain info.</p>
             </div>
-            <a href="/logs/debug"
+            <a href="<%= ghoslerUrl %>/logs/debug"
                class="inline-block bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded transition duration-300">View
                 Logs</a>
         </div>
@@ -53,7 +53,7 @@
                 <h3 class="text-lg font-bold text-gray-300 mb-4">Error Logs</h3>
                 <p class="text-gray-400 mb-4">Check error level logs to see if something went wrong.</p>
             </div>
-            <a href="/logs/error"
+            <a href="<%= ghoslerUrl %>/logs/error"
                class="inline-block bg-pink-900 hover:bg-pink-950 text-white font-bold py-2 px-4 rounded transition duration-300">View
                 Logs</a>
         </div>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Login - Ghosler</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link href="/styles/style.css" rel="stylesheet"/>
+    <link href="<%= ghoslerUrl %>/styles/style.css" rel="stylesheet"/>
 </head>
 
 <body class="bg-gray-900 text-gray-300 flex flex-col min-h-screen font-serif">
@@ -18,7 +18,7 @@
         <h2 class="text-xl font-bold text-gray-300 mb-4 text-left">Login</h2>
         <hr class="border-gray-600 mb-6 md:hidden">
 
-        <form action="/login" method="post">
+        <form action="<%= ghoslerUrl %>/login" method="post">
             <!-- check is required in case of wrong credentials -->
             <% if (typeof redirect !== 'undefined' && redirect) { %>
                 <div class="hidden">

--- a/views/partials/common/header.ejs
+++ b/views/partials/common/header.ejs
@@ -12,7 +12,7 @@
                 </a>
 
                 <div class="flex items-baseline space-x-1.5">
-                    <a href="/"
+                    <a href="<%= ghoslerUrl %>/"
                        class="text-2xl font-bold text-gray-300 hover:text-white transition duration-300">Ghosler</a>
 
                     <% if (version) { %>
@@ -36,7 +36,7 @@
                         <span title="Logout">
                             <svg class="cursor-pointer h-8 w-8 text-gray-300 hover:text-white transition duration-300"
                                  fill="currentColor" viewBox="0 0 24 24"
-                                 onclick="if (confirm('Do you really want to logout? Click OK to logout.')) {window.location = '/logout'}"
+                                 onclick="if (confirm('Do you really want to logout? Click OK to logout.')) {window.location = '<%= ghoslerUrl %>/logout'}"
                                  xmlns="http://www.w3.org/2000/svg">
                                 <path d="M20.9 11.6c-.1-.1-.1-.2-.2-.3l-3-3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l1.3 1.3H13c-.6 0-1 .4-1 1s.4 1 1 1h4.6l-1.3 1.3c-.4.4-.4 1 0 1.4.2.2.5.3.7.3s.5-.1.7-.3l3-3c.1-.1.2-.2.2-.3.1-.3.1-.5 0-.8z"></path>
                                 <path d="M15.5 18.1c-1.1.6-2.3.9-3.5.9-3.9 0-7-3.1-7-7s3.1-7 7-7c1.2 0 2.4.3 3.5.9.5.3 1.1.1 1.4-.4.3-.5.1-1.1-.4-1.4C15.1 3.4 13.6 3 12 3c-5 0-9 4-9 9s4 9 9 9c1.6 0 3.1-.4 4.5-1.2.5-.3.6-.9.4-1.4-.3-.4-.9-.6-1.4-.3z"></path>

--- a/views/partials/settings/customise.ejs
+++ b/views/partials/settings/customise.ejs
@@ -143,7 +143,7 @@
         <p class="text-gray-400 mb-4">Note: Save Changes before Preview</p>
 
         <button type="button" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-                onclick="parent.open('/preview', '_blank')">Preview
+                onclick="parent.open('<%= ghoslerUrl %>/preview', '_blank')">Preview
         </button>
     </div>
 </div>

--- a/views/partials/settings/profile.ejs
+++ b/views/partials/settings/profile.ejs
@@ -16,7 +16,7 @@
         </div>
 
 
-        <button type="button" onclick="window.location='/password'"
+        <button type="button" onclick="window.location='<%= ghoslerUrl %>/password'"
                 class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Change Password
         </button>
     </div>

--- a/views/partials/settings/template.ejs
+++ b/views/partials/settings/template.ejs
@@ -19,12 +19,12 @@
         </div>
 
         <div class="flex flex-wrap gap-x-2 text-xs text-gray-300 mt-2">
-            <a href="/settings/template" type="button"
+            <a href="<%= ghoslerUrl %>/settings/template" type="button"
                class="bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold py-2 px-4 rounded mb-2"
                onclick="">Upload Template
             </a>
 
-            <a href="/settings/template/download/base" type="button"
+            <a href="<%= ghoslerUrl %>/settings/template/download/base" type="button"
                class="bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold py-2 px-4 rounded mb-2"
                onclick="">Download Base Template
             </a>


### PR DESCRIPTION
This pull request makes a few changes to support serving Ghosler behind a reverse proxy at a subdirectory instead of hosting it at a subdomain. The existing use case should still function identically.

It accomplishes this by implementing a middleware that provides the configs.ghosler.url to all views as a variable and modifying the views to prepend all paths with this value. The result is essentially dynamically generated absolute paths to resources.

It was also necessary to modify the post function of the settings form such that it did not overwrite the ghosler.url improperly. It will still update on submission but will now detect a subdirectory via the Referer header.

Note to use Ghosler at a subdirectory you do still need to manually configure the ghosler.url before initially starting, I didn't really have a good idea on how to get around that. But now it won't overwrite this setting with the wrong data.

For reference, a minimal nginx stub looks like this:

```nginx
    location /ghosler/ {
        proxy_pass              http://127.0.0.1:2370;

        # Preserve the base path
        rewrite ^/ghosler/(.*)$ /$1 break;
        proxy_redirect          / /ghosler/;
    }
```

An alternative approach would have been to create a new configuration variable for the baseURI for the routes. I thought it was better to not introduce a new variable but this might be a better approach as it might be more clear how to achieve such a setup and would mean even less complicated reverse proxy rules.