### PR TITLE
deal with #portal problem

### DIFF
--- a/utils/mail/mailer.js
+++ b/utils/mail/mailer.js
@@ -253,7 +253,7 @@ export default class NewsletterMailer {
      */
     async #transporter(mailConfig) {
         return nodemailer.createTransport({
-            secure: true,
+            secure: false,
             host: mailConfig.host,
             port: mailConfig.port,
             auth: { user: mailConfig.auth.user, pass: mailConfig.auth.pass },

--- a/utils/newsletter.js
+++ b/utils/newsletter.js
@@ -267,9 +267,14 @@ export default class Newsletter {
             if (elementUrl === '#' || !elementUrl) return;
 
             /** @type {string | null} */
-            let urlHost = null;
+             let urlHost = null;
 
             elementUrl = he.decode(elementUrl);
+
+            // ignore non http/https begin
+            if (!elementUrl.startsWith('http://') && !elementUrl.startsWith('https://')) {
+                return;
+            }
 
             try {
                 urlHost = new URL(elementUrl).host;
@@ -278,6 +283,7 @@ export default class Newsletter {
                     logTags.Newsletter,
                     Error(`Invalid URL found: ${elementUrl}, ${error.stack}.`),
                 );
+                return; // skip fail
             }
 
             if (


### PR DESCRIPTION
```
[2025-07-05 04:08:03 UTC] => [ERROR] => Newsletter: Error: Invalid URL found: #/portal/, TypeError [ERR_INVALID_URL]: Invalid URL
at new NodeError (node:internal/errors:405:5)
at new URL (node:internal/url:676:13)
at Element.<anonymous> (file:///usr/src/app/utils/newsletter.js:275:27)
at LoadedCheerio.each (file:///usr/src/app/node_modules/cheerio/lib/esm/api/traversing.js:461:26)
at #injectUrlTracking (file:///usr/src/app/utils/newsletter.js:259:45)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async Newsletter.renderTemplate (file:///usr/src/app/utils/newsletter.js:162:19)
at async Newsletter.send (file:///usr/src/app/utils/newsletter.js:39:13).
at Element.<anonymous> (file:///usr/src/app/utils/newsletter.js:279:21)
at LoadedCheerio.each (file:///usr/src/app/node_modules/cheerio/lib/esm/api/traversing.js:461:26)
at #injectUrlTracking (file:///usr/src/app/utils/newsletter.js:259:45)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async Newsletter.renderTemplate (file:///usr/src/app/utils/newsletter.js:162:19)
at async Newsletter.send (file:///usr/src/app/utils/newsletter.js:39:13)
```

to skip http/https to deal this problem